### PR TITLE
DJ2-478: Align remaining dashboard cards into a 2-column grid on Home/National

### DIFF
--- a/src/app/pages/dashboard/national/national.html
+++ b/src/app/pages/dashboard/national/national.html
@@ -14,7 +14,7 @@
                 <app-pre-loader></app-pre-loader>
                 } @else {
                 <!-- @if(this.selectedLedgerYear()) { -->
-                <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails"></app-grid-view>
+                <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails" [columns]="2"></app-grid-view>
                 <!-- } -->
                 }
             </div>

--- a/src/app/pages/home/dashboard-map-section/dashboard-map-section.html
+++ b/src/app/pages/home/dashboard-map-section/dashboard-map-section.html
@@ -63,7 +63,7 @@
     <app-pre-loader></app-pre-loader>
     } @else {
     <!-- Grid with data -->
-    <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails"></app-grid-view>
+    <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails" [columns]="2"></app-grid-view>
     }
     <!-- View Dashboard button -->
     @if (selectedStateIdSignal()) {

--- a/src/app/shared/components/grid-view/grid-view.html
+++ b/src/app/shared/components/grid-view/grid-view.html
@@ -1,4 +1,4 @@
-<div class="flex-grow-1 explore-data-grid my-3">
+<div class="flex-grow-1 explore-data-grid my-3" [class.explore-data-grid--cols-2]="columns() === 2">
   @for (item of gridData(); track $index) {
   <div class="p-2">
     <p class="mb-0 fw-bold fs-5">

--- a/src/app/shared/components/grid-view/grid-view.spec.ts
+++ b/src/app/shared/components/grid-view/grid-view.spec.ts
@@ -1,10 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GridView } from './grid-view';
+import { ExploresectionTable } from '../../../core/models/interfaces';
 
 describe('GridView', () => {
   let component: GridView;
   let fixture: ComponentFixture<GridView>;
+
+  const gridData: ExploresectionTable[] = [
+    { sequence: 0, label: 'Population', value: '100', info: '', src: '', tooltip: '' },
+    { sequence: 1, label: 'ULBs', value: '50', info: '', src: '', tooltip: '' },
+  ];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,10 +20,26 @@ describe('GridView', () => {
 
     fixture = TestBed.createComponent(GridView);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('gridData', gridData);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('defaults to a 3-column grid', () => {
+    const gridEl: HTMLElement = fixture.nativeElement.querySelector('.explore-data-grid');
+    expect(gridEl.classList.contains('explore-data-grid--cols-2')).toBeFalse();
+  });
+
+  // DJ2-478: Home Page / National Dashboard opt into a 2-column layout so their
+  // remaining data cards form a clean grid with no blank cells.
+  it('applies the cols-2 modifier class when columns=2', () => {
+    fixture.componentRef.setInput('columns', 2);
+    fixture.detectChanges();
+
+    const gridEl: HTMLElement = fixture.nativeElement.querySelector('.explore-data-grid');
+    expect(gridEl.classList.contains('explore-data-grid--cols-2')).toBeTrue();
   });
 });

--- a/src/app/shared/components/grid-view/grid-view.ts
+++ b/src/app/shared/components/grid-view/grid-view.ts
@@ -10,4 +10,5 @@ import { ExploresectionTable } from '../../../core/models/interfaces';
 })
 export class GridView {
   gridData = input<ExploresectionTable[]>();
+  columns = input<number>(3);
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -299,6 +299,12 @@ input::-webkit-inner-spin-button {
     grid-template-columns: repeat(3, 1fr);
 }
 
+// DJ2-478: Home Page / National Dashboard opt into a 2-column layout so their
+// remaining 4 data cards form a clean 2x2 grid (no blank cells) at every breakpoint.
+.explore-data-grid.explore-data-grid--cols-2 {
+    grid-template-columns: repeat(2, 1fr);
+}
+
 @media (max-width: 767px) {
     .explore-data-grid {
         grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
Follow-up to #207 (already merged). With the credit rating cards hidden, the Home Page and National Dashboard were left with 4 data cards rendered in a 3-column grid, producing an uneven 3+1 split with a blank trailing cell.

- Adds a `columns` input to `GridView` (default `3`, unchanged for City and State dashboards which reuse the same component)
- Home Page and National Dashboard opt into `columns=2` via a new `.explore-data-grid--cols-2` modifier class
- Produces a clean 2x2 grid with no blank cells at desktop, tablet, and mobile widths
- Adds spec coverage for the new `columns` input default and `cols-2` modifier behavior

## Test plan
- [x] Added spec coverage in `grid-view.spec.ts`
- [x] `tsc --noEmit` passes
- [x] `ng build` (browser + SSR) succeeds
- [ ] Manual verification on desktop/tablet/mobile views

Jira: https://janaagrahapm.atlassian.net/browse/DJ2-478

🤖 Generated with [Claude Code](https://claude.com/claude-code)