### PR TITLE
DJ2-478: Hide ULB credit rating cards and fix grid alignment

### DIFF
--- a/src/app/pages/dashboard/national/national.html
+++ b/src/app/pages/dashboard/national/national.html
@@ -14,7 +14,7 @@
                 <app-pre-loader></app-pre-loader>
                 } @else {
                 <!-- @if(this.selectedLedgerYear()) { -->
-                <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails"></app-grid-view>
+                <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails" [columns]="2"></app-grid-view>
                 <!-- } -->
                 }
             </div>

--- a/src/app/pages/home/dashboard-map-section/dashboard-map-section.html
+++ b/src/app/pages/home/dashboard-map-section/dashboard-map-section.html
@@ -63,7 +63,7 @@
     <app-pre-loader></app-pre-loader>
     } @else {
     <!-- Grid with data -->
-    <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails"></app-grid-view>
+    <app-grid-view [gridData]="nationalDashboardService.exploreData().gridDetails" [columns]="2"></app-grid-view>
     }
     <!-- View Dashboard button -->
     @if (selectedStateIdSignal()) {

--- a/src/app/shared/components/grid-view/grid-view.html
+++ b/src/app/shared/components/grid-view/grid-view.html
@@ -1,4 +1,4 @@
-<div class="flex-grow-1 explore-data-grid my-3">
+<div class="flex-grow-1 explore-data-grid my-3" [class.explore-data-grid--cols-2]="columns() === 2">
   @for (item of gridData(); track $index) {
   <div class="p-2">
     <p class="mb-0 fw-bold fs-5">

--- a/src/app/shared/components/grid-view/grid-view.spec.ts
+++ b/src/app/shared/components/grid-view/grid-view.spec.ts
@@ -1,10 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GridView } from './grid-view';
+import { ExploresectionTable } from '../../../core/models/interfaces';
 
 describe('GridView', () => {
   let component: GridView;
   let fixture: ComponentFixture<GridView>;
+
+  const gridData: ExploresectionTable[] = [
+    { sequence: 0, label: 'Population', value: '100', info: '', src: '', tooltip: '' },
+    { sequence: 1, label: 'ULBs', value: '50', info: '', src: '', tooltip: '' },
+  ];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,10 +20,26 @@ describe('GridView', () => {
 
     fixture = TestBed.createComponent(GridView);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('gridData', gridData);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('defaults to a 3-column grid', () => {
+    const gridEl: HTMLElement = fixture.nativeElement.querySelector('.explore-data-grid');
+    expect(gridEl.classList.contains('explore-data-grid--cols-2')).toBeFalse();
+  });
+
+  // DJ2-478: Home Page / National Dashboard opt into a 2-column layout so their
+  // remaining data cards form a clean grid with no blank cells.
+  it('applies the cols-2 modifier class when columns=2', () => {
+    fixture.componentRef.setInput('columns', 2);
+    fixture.detectChanges();
+
+    const gridEl: HTMLElement = fixture.nativeElement.querySelector('.explore-data-grid');
+    expect(gridEl.classList.contains('explore-data-grid--cols-2')).toBeTrue();
   });
 });

--- a/src/app/shared/components/grid-view/grid-view.ts
+++ b/src/app/shared/components/grid-view/grid-view.ts
@@ -10,4 +10,5 @@ import { ExploresectionTable } from '../../../core/models/interfaces';
 })
 export class GridView {
   gridData = input<ExploresectionTable[]>();
+  columns = input<number>(3);
 }

--- a/src/app/shared/services/national-dashboard.spec.ts
+++ b/src/app/shared/services/national-dashboard.spec.ts
@@ -1,16 +1,90 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { NationalDashboard } from './national-dashboard';
+import { CommonService } from '../../core/services/common.service';
+import { AssetsService } from '../../core/services/assets/assets.service';
+import { ExploreSectionResponse, ExploresectionTable } from '../../core/models/interfaces';
+import { ICreditRatingData } from '../../core/models/creditRating/creditRatingResponse';
 
 describe('NationalDashboard', () => {
   let service: NationalDashboard;
+  let commonServiceSpy: jasmine.SpyObj<CommonService>;
+  let assetsServiceSpy: jasmine.SpyObj<AssetsService>;
+
+  const baseGridDetails: ExploresectionTable[] = [
+    { sequence: 0, label: 'Population', value: '100', info: '', src: '', tooltip: '' },
+    { sequence: 1, label: 'ULBs', value: '50', info: '', src: '', tooltip: '' },
+    { sequence: 2, label: 'States', value: '28', info: '', src: '', tooltip: '' },
+  ];
+
+  const exploreSectionResponse: ExploreSectionResponse = {
+    gridDetails: baseGridDetails,
+    lastModifiedAt: '2026-01-01',
+    popCat: '',
+    state: {} as any,
+    ulbId: '',
+    ulbName: '',
+    ulbType: '' as any,
+  };
+
+  const creditRatingReport: ICreditRatingData[] = [
+    { ulb: 'ULB A', state: 'Karnataka', agency: 'CRISIL', creditRating: 'AA', creditrating: 'AA', status: '', date: '' },
+    { ulb: 'ULB B', state: 'Karnataka', agency: 'CRISIL', creditRating: 'BB', creditrating: 'BB', status: '', date: '' },
+  ];
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    commonServiceSpy = jasmine.createSpyObj('CommonService', [
+      'getExploreSectionData',
+      'setDataForVisualizationCount',
+    ]);
+    commonServiceSpy.getExploreSectionData.and.returnValue(of(exploreSectionResponse));
+
+    assetsServiceSpy = jasmine.createSpyObj('AssetsService', ['fetchCreditRatingReport']);
+    assetsServiceSpy.fetchCreditRatingReport.and.returnValue(of(creditRatingReport));
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: CommonService, useValue: commonServiceSpy },
+        { provide: AssetsService, useValue: assetsServiceSpy },
+      ],
+    });
     service = TestBed.inject(NationalDashboard);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  // DJ2-478: 'ULBs Credit Rating Reports' and 'ULBs With Investment Grade Rating'
+  // must not appear on the Home Page.
+  it('should hide the credit rating cards on the Home Page', () => {
+    service.fetchCreditRatingsData('home', true);
+
+    const labels = service.exploreData().gridDetails.map((item) => item.label);
+    expect(labels).not.toContain('ULBs Credit Rating Reports');
+    expect(labels).not.toContain('ULBs With Investment Grade Rating');
+  });
+
+  // DJ2-478: same two cards, plus the National-only 'ULBs With Rating A & Above'
+  // card, must not appear on the National Dashboard.
+  it('should hide the credit rating cards on the National Dashboard', () => {
+    service.fetchCreditRatingsData('national');
+
+    const labels = service.exploreData().gridDetails.map((item) => item.label);
+    expect(labels).not.toContain('ULBs Credit Rating Reports');
+    expect(labels).not.toContain('ULBs With Investment Grade Rating');
+    expect(labels).not.toContain('ULBs With Rating A & Above');
+  });
+
+  // DJ2-478: hiding the credit rating cards should not disturb the other
+  // dashboard cards or leave gaps in the grid.
+  it('should keep the remaining grid cards unchanged and gapless', () => {
+    service.fetchCreditRatingsData('national');
+
+    const grid = service.exploreData().gridDetails;
+    expect(grid.length).toBe(baseGridDetails.length);
+    expect(grid.every((item) => !!item)).toBeTrue();
+    expect(grid.map((item) => item.label)).toEqual(baseGridDetails.map((item) => item.label));
   });
 });

--- a/src/app/shared/services/national-dashboard.ts
+++ b/src/app/shared/services/national-dashboard.ts
@@ -152,36 +152,39 @@ export class NationalDashboard {
 
           let result: ExploresectionTable[] = [
             ...res.gridDetails,
-            {
-              sequence: 3,
-              label: 'ULBs Credit Rating Reports',
-              value: `${this.totalCreditRating}`,
-              info: '',
-              src: '',
-              "tooltip": ""
-            },
-            {
-              sequence: 4,
-              label: 'ULBs With Investment Grade Rating',
-              value: `${this.cr_above_BBB_minus}`,
-              info: '',
-              src: '',
-              "tooltip": ""
-            },
+            // DJ2-478: 'ULBs Credit Rating Reports' and 'ULBs With Investment Grade Rating'
+            // cards hidden from Home Page and National Dashboard per D&I team request.
+            // {
+            //   sequence: 3,
+            //   label: 'ULBs Credit Rating Reports',
+            //   value: `${this.totalCreditRating}`,
+            //   info: '',
+            //   src: '',
+            //   "tooltip": ""
+            // },
+            // {
+            //   sequence: 4,
+            //   label: 'ULBs With Investment Grade Rating',
+            //   value: `${this.cr_above_BBB_minus}`,
+            //   info: '',
+            //   src: '',
+            //   "tooltip": ""
+            // },
           ];
           result.sort((a: any, b: any) => a.sequence - b.sequence);
 
-          if (this.page() === 'national') {
-            const obj = {
-              sequence: 5,
-              label: 'ULBs With Rating A & Above',
-              value: `${this.cr_above_a}`,
-              info: '',
-              src: '',
-              "tooltip": ""
-            }
-            result[5] = obj;
-          }
+          // DJ2-478: 'ULBs With Rating A & Above' card hidden from National Dashboard per D&I team request.
+          // if (this.page() === 'national') {
+          //   const obj = {
+          //     sequence: 5,
+          //     label: 'ULBs With Rating A & Above',
+          //     value: `${this.cr_above_a}`,
+          //     info: '',
+          //     src: '',
+          //     "tooltip": ""
+          //   }
+          //   result[5] = obj;
+          // }
 
           const data = { gridDetails: result, lastModifiedAt: res.lastModifiedAt };
           this.exploreData.set(data);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -299,6 +299,12 @@ input::-webkit-inner-spin-button {
     grid-template-columns: repeat(3, 1fr);
 }
 
+// DJ2-478: Home Page / National Dashboard opt into a 2-column layout so their
+// remaining 4 data cards form a clean 2x2 grid (no blank cells) at every breakpoint.
+.explore-data-grid.explore-data-grid--cols-2 {
+    grid-template-columns: repeat(2, 1fr);
+}
+
 @media (max-width: 767px) {
     .explore-data-grid {
         grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
Promotes the DJ2-478 feature (already merged and QA-verified on `development` via #207 and #208, and raised for `staging` via #209) to `main`.

- Hides "ULBs Credit Rating Reports", "ULBs With Investment Grade Rating", and the National-only "ULBs With Rating A & Above" cards from the Home Page and National Dashboard (commented out, not deleted, for easy restoration)
- Fixes a latent sparse-array bug where the National-only card was inserted via index assignment (`result[5] = obj`), which would have left undefined grid slots once earlier entries were removed
- Adds a `columns` input to the shared `GridView` component (default `3`, unchanged for City/State dashboards) so Home Page and National Dashboard can opt into a 2-column layout, producing a clean 2x2 grid with no blank cells across desktop, tablet, and mobile
- Adds spec coverage for both the hidden cards and the new grid column behavior

This branch was created from `main` and only the two DJ2-478 commits were cherry-picked over, so this PR contains only this feature's changes rather than any unrelated history.

## Test plan
- [x] QA-verified on development
- [x] `tsc --noEmit` passes
- [x] `ng build` (browser + SSR) succeeds
- [x] Unit tests added for both changes

Jira: https://janaagrahapm.atlassian.net/browse/DJ2-478

🤖 Generated with [Claude Code](https://claude.com/claude-code)